### PR TITLE
Supported Hex string: 'x'

### DIFF
--- a/bufferpack.js
+++ b/bufferpack.js
@@ -48,6 +48,28 @@ function BufferPack() {
     for (var t, i = 0; i < l; a[p+i] = (t=v.charCodeAt(i))?t:0, i++);
   };
 
+  // ASCII characters strings
+  m._DeHexString = function (a, p, n) {
+    var rv = [], r, c1, c2;
+    for (var i = 0; i < n; i++) {
+      r = a[i];
+      c1 = Math.floor(r / 16);
+      c2 = r % 16;
+      rv.push(c1.toString(16))
+      rv.push(c2.toString(16))
+    }
+    return rv.join('');
+  };
+  m._EnHexString = function (n, s, a, p, v, i) {
+    var r, c1, c2;
+    for (var j = 0; j < n; j++) {
+      c1 = v[p+j*2];
+      c2 = v[p+j*2+1];
+      r = parseInt(c1, 16) * 16 + parseInt(c2, 16);
+      a[j] = r;
+    }
+  };
+
   // ASCII character strings null terminated
   m._DeNullString = function (a, p, l, v) {
     var str = m._DeString(a, p, l, v);
@@ -133,6 +155,7 @@ function BufferPack() {
   m._elLut = {'A': {en: m._EnArray, de: m._DeArray},
               's': {en: m._EnString, de: m._DeString},
               'S': {en: m._EnString, de: m._DeNullString},
+              'x': {en: m._EnHexString, de: m._DeHexString},
               'c': {en: m._EnChar, de: m._DeChar},
               'b': {en: m._EnInt, de: m._DeInt, len: 1, bSigned: true, min: -Math.pow(2, 7), max: Math.pow(2, 7) - 1},
               'B': {en: m._EnInt, de: m._DeInt, len: 1, bSigned: false, min: 0, max: Math.pow(2, 8) - 1},
@@ -197,7 +220,7 @@ function BufferPack() {
       }
 
       switch (m[2]) {
-      case 'A': case 's': case 'S':
+      case 'A': case 's': case 'S': case 'x':
         rv.push(this._elLut[m[2]].de(a, p, n));
         break;
       case 'c': case 'b': case 'B': case 'h': case 'H':
@@ -261,6 +284,13 @@ function BufferPack() {
         i += n;
         break;
       case 'x':
+        el = this._elLut[m[2]];
+        if ((i + n) > values.length) { return false; }
+        this._elLut[m[2]].en(n, s, a, p, values, i);
+        n = n*2;
+        i += n;
+        break;
+      case 'x':
         for (j = 0; j < n; j++) { a[p+j] = 0; }
         break;
       }
@@ -284,7 +314,6 @@ function BufferPack() {
       if(m[2] === 'S') {
         n = values[i].length + 1; // Add one for null byte
       }
-
       sum += n;
       i++;
     }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     }
   ],
   "devDependencies": {
-    "mocha": "= 0.10.2",
-    "should": "= 0.5.1"
+    "mocha": "= 1.10.0",
+    "should": "= 1.2.2"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha test/*.test.js --reporter spec"

--- a/test/hexstring.test.js
+++ b/test/hexstring.test.js
@@ -1,0 +1,70 @@
+
+require('should');
+require('buffer');
+
+var bufferpack = require('..');
+
+describe('Hex String', function() {
+  var values = '01eb6d8eafc3';
+  var format = '6x';
+
+  describe('#pack()', function() {
+    var packed = bufferpack.pack(format, values);
+
+    it('should have packed size of 6', function() {
+      packed.length.should.equal(6);
+    });
+
+    it('should back fine', function() {
+      packed[0].should.equal(parseInt(values[0*2], 16) * 16 + parseInt(values[0*2+1], 16));
+      packed[1].should.equal(parseInt(values[1*2], 16) * 16 + parseInt(values[1*2+1], 16));
+      packed[2].should.equal(parseInt(values[2*2], 16) * 16 + parseInt(values[2*2+1], 16));
+      packed[3].should.equal(parseInt(values[3*2], 16) * 16 + parseInt(values[3*2+1], 16));
+      packed[4].should.equal(parseInt(values[4*2], 16) * 16 + parseInt(values[4*2+1], 16));
+      packed[5].should.equal(parseInt(values[5*2], 16) * 16 + parseInt(values[5*2+1], 16));
+    });
+  });
+
+
+  var buffSize = bufferpack.calcLength(format, values);
+
+  it('buffer size should be 6', function() {
+    buffSize.should.equal(6);
+  });
+
+  var buffer = new Buffer(buffSize);
+
+  describe('#packTo()', function() {
+    bufferpack.packTo(format, buffer, 0, values);
+
+    it('should pack fine', function() {
+      buffer[0].should.equal(parseInt(values[0*2], 16) * 16 + parseInt(values[0*2+1], 16));
+      buffer[1].should.equal(parseInt(values[1*2], 16) * 16 + parseInt(values[1*2+1], 16));
+      buffer[2].should.equal(parseInt(values[2*2], 16) * 16 + parseInt(values[2*2+1], 16));
+      buffer[3].should.equal(parseInt(values[3*2], 16) * 16 + parseInt(values[3*2+1], 16));
+      buffer[4].should.equal(parseInt(values[4*2], 16) * 16 + parseInt(values[4*2+1], 16));
+      buffer[5].should.equal(parseInt(values[5*2], 16) * 16 + parseInt(values[5*2+1], 16));
+    });
+  });
+
+  describe('#unpack()', function() {
+    var unpacked = bufferpack.unpack(format, buffer, 0);
+
+    it('should return an array', function() {
+      unpacked.should.be.an.instanceof(Array);
+    });
+
+    it('should return same values as in values', function() {
+      unpacked[0].should.equal(values);
+    });
+
+  describe('zero with null term string', function() {
+    var packed = bufferpack.pack('6x', values);
+
+    it('third should be ""', function() {
+      var unpacked = bufferpack.unpack('6x(n)', packed);
+      unpacked.n.should.equal(values);
+    });
+  });
+  });
+});


### PR DESCRIPTION
1. Added Hex string supporting for a little requirement from my job works.
   I use a temp format name: `x`, because I found this format in [PHP](http://www.php.net/manual/en/function.pack.php) is `H` but this program have had `H` for unsigned short.
   I also write a test script in `./test/hexstring.js`
2. Updated the dev dependencies versions
   The package `should` doesn't work well in the previous version. So I updated the package info.

Hope to be useful.

Thanks.
