### PR TITLE
Fix length calculation error when using padding before strings

### DIFF
--- a/bufferpack.js
+++ b/bufferpack.js
@@ -178,7 +178,7 @@ function BufferPack() {
     var s;
     var rk = [];
     var rv = [];
-    
+
     while (m = re.exec(fmt)) {
       n = ((m[1]==undefined)||(m[1]==''))?1:parseInt(m[1]);
 
@@ -210,7 +210,7 @@ function BufferPack() {
       rk.push(m[4]); // Push key on to array
 
       p += n*s;
-    }   
+    }
 
     rv = Array.prototype.concat.apply([], rv)
 
@@ -286,7 +286,9 @@ function BufferPack() {
       }
 
       sum += n;
-      i++;
+      if(m[2] !== 'x') {
+        i++;
+      }
     }
     return sum;
   };

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     }
   ],
   "devDependencies": {
-    "mocha": "= 0.10.2",
-    "should": "= 0.5.1"
+    "mocha": "1.x",
+    "should": "3.x"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha test/*.test.js --reporter spec"

--- a/test/cstring.test.js
+++ b/test/cstring.test.js
@@ -6,27 +6,28 @@ var bufferpack = require('..');
 
 describe('C String', function() {
   var values = [1, 2, 3, 'test', 5, 6, 7];
-  var format = '<bbbSbbb';
+  var format = '<bbbxSbbb';
 
   describe('#pack()', function() {
     var packed = bufferpack.pack(format, values);
 
-    it('should have packed size of 11', function() {
-      packed.length.should.equal(11);
+    it('should have packed size of 12', function() {
+      packed.length.should.equal(12);
     });
 
     it('should back fine', function() {
       packed[0].should.equal(values[0]);
       packed[1].should.equal(values[1]);
       packed[2].should.equal(values[2]);
-      packed[3].should.equal(values[3].charCodeAt(0));
-      packed[4].should.equal(values[3].charCodeAt(1));
-      packed[5].should.equal(values[3].charCodeAt(2));
-      packed[6].should.equal(values[3].charCodeAt(3));
-      packed[7].should.equal(0);
-      packed[8].should.equal(values[4]);
-      packed[9].should.equal(values[5]);
-      packed[10].should.equal(values[6]);
+      packed[3].should.equal(0);
+      packed[4].should.equal(values[3].charCodeAt(0));
+      packed[5].should.equal(values[3].charCodeAt(1));
+      packed[6].should.equal(values[3].charCodeAt(2));
+      packed[7].should.equal(values[3].charCodeAt(3));
+      packed[8].should.equal(0);
+      packed[9].should.equal(values[4]);
+      packed[10].should.equal(values[5]);
+      packed[11].should.equal(values[6]);
     });
   });
 
@@ -34,7 +35,7 @@ describe('C String', function() {
   var buffSize = bufferpack.calcLength(format, values);
 
   it('buffer size should be 11', function() {
-    buffSize.should.equal(11);
+    buffSize.should.equal(12);
   });
 
   var buffer = new Buffer(buffSize);
@@ -46,14 +47,15 @@ describe('C String', function() {
       buffer[0].should.equal(values[0]);
       buffer[1].should.equal(values[1]);
       buffer[2].should.equal(values[2]);
-      buffer[3].should.equal(values[3].charCodeAt(0));
-      buffer[4].should.equal(values[3].charCodeAt(1));
-      buffer[5].should.equal(values[3].charCodeAt(2));
-      buffer[6].should.equal(values[3].charCodeAt(3));
-      buffer[7].should.equal(0);
-      buffer[8].should.equal(values[4]);
-      buffer[9].should.equal(values[5]);
-      buffer[10].should.equal(values[6]);
+      buffer[3].should.equal(0);
+      buffer[4].should.equal(values[3].charCodeAt(0));
+      buffer[5].should.equal(values[3].charCodeAt(1));
+      buffer[6].should.equal(values[3].charCodeAt(2));
+      buffer[7].should.equal(values[3].charCodeAt(3));
+      buffer[8].should.equal(0);
+      buffer[9].should.equal(values[4]);
+      buffer[10].should.equal(values[5]);
+      buffer[11].should.equal(values[6]);
     });
   });
 

--- a/test/cstring.test.js
+++ b/test/cstring.test.js
@@ -74,17 +74,17 @@ describe('C String', function() {
       unpacked[6].should.equal(values[6]);
     });
 
-  describe('zero with null term string', function() {
-    var values = ['foo', 'bar', 0, 'asdf'];
-    var packed = bufferpack.pack('<SSbS', values);
+    describe('zero with null term string', function() {
+      var values = ['foo', 'bar', 0, 'asdf'];
+      var packed = bufferpack.pack('<SSbS', values);
 
-    it('third should be ""', function() {
-      var unpacked = bufferpack.unpack('<S(first)S(second)S(third)S(forth)', packed);
-      unpacked.first.should.equal('foo');
-      unpacked.second.should.equal('bar');
-      unpacked.third.should.equal('');
-      unpacked.forth.should.equal('asdf');
+      it('third should be ""', function() {
+        var unpacked = bufferpack.unpack('<S(first)S(second)S(third)S(forth)', packed);
+        unpacked.first.should.equal('foo');
+        unpacked.second.should.equal('bar');
+        unpacked.third.should.equal('');
+        unpacked.forth.should.equal('asdf');
+      });
     });
-  });
   });
 });

--- a/test/keys.test.js
+++ b/test/keys.test.js
@@ -14,7 +14,7 @@ describe('Keying', function() {
     var unpacked = bufferpack.unpack(format, packed, 0);
 
     it('should return an object', function() {
-      unpacked.should.be.a('object');
+      unpacked.should.be.an.instanceOf(Object);
       unpacked.should.have.property('first');
       unpacked.first.should.equal(1);
       unpacked.should.have.property('second');
@@ -30,5 +30,5 @@ describe('Keying', function() {
     it('should returned object should have 5 properties', function() {
       Object.keys(unpacked).length.should.equal(5);
     });
-  });  
+  });
 });


### PR DESCRIPTION
A format like `"xS"` where padding is used before a string fails when using `pack` or `calculateLength`. The `calculateLength` function incorrectly consumes a value from the array.
