### PR TITLE
Update bufferpack.js

### DIFF
--- a/bufferpack.js
+++ b/bufferpack.js
@@ -272,7 +272,7 @@ function BufferPack() {
 
   // Pack the supplied values into a new octet array, according to the fmt string
   m.pack = function (fmt, values) {
-    return this.packTo(fmt, new Buffer(this.calcLength(fmt, values)), 0, values);
+    return this.packTo(fmt, new Array(this.calcLength(fmt, values)), 0, values);
   };
 
   // Determine the number of bytes represented by the format string


### PR DESCRIPTION
Fixed an error where `new Array()` should be used instead of `new Buffer()` when calling `pathTo()` internally.
